### PR TITLE
Update to add Windows support

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'forward3ddev-r'
-version '0.0.2'
+version '0.0.3'
 source 'UNKNOWN'
 author 'forward3d'
 license 'Apache License, Version 2.0'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,14 @@ class r {
     'RedHat': {
       package {'R-core': ensure => installed}
     }
+    'windows': {
+      # Choco package does not install static version and does not add R to PATH
+      exec { 'Install R Windows':
+        command  => template('r/windows_install_r.ps1.erb'),
+        provider => powershell,
+        unless   => "if(Test-Path \"\${Env:ProgramFiles}\\R\\R-*\\bin\\R.exe\"){exit 0}else{exit 1}",
+      }
+    }
     default: { fail("Not supported on osfamily ${::osfamily}") }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,13 @@
 class r {
 
-  case $osfamily {
+  case $::osfamily {
     'Debian': {
-      package {"r-base": ensure => installed}
+      package {'r-base': ensure => installed}
     }
     'RedHat': {
-      package {"R-core": ensure => installed}
+      package {'R-core': ensure => installed}
     }
-    default: { fail("Not supported on osfamily $osfamily") }
+    default: { fail("Not supported on osfamily ${::osfamily}") }
   }
 
 }
-

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,14 +1,52 @@
-define r::package($r_path = '/usr/bin/R', $repo = 'http://cran.rstudio.com', $dependencies = false) {
+define r::package($r_path = '', $repo = 'http://cran.rstudio.com', $dependencies = false) {
 
-  $command = $dependencies ? {
-    true    => "${r_path} -e \"install.packages('${name}', repos='${repo}', dependencies = TRUE)\"",
-    default => "${r_path} -e \"install.packages('${name}', repos='${repo}', dependencies = FALSE)\""
-  }
+    case $::osfamily {
+    '^(Debian|RedHat)$': {
 
-  exec { "install_r_package_${name}":
-    command => $command,
-    unless  => "${r_path} -q -e '\"${name}\" %in% installed.packages()' | grep 'TRUE'",
-    require => Class['r']
+      if $r_path == '' {
+        $binary = '/usr/bin/R'
+      }
+      else
+      {
+        $binary = $r_path
+      }
+
+      $command = $dependencies ? {
+        true    => "${binary} -e \"install.packages('${name}', repos='${repo}', dependencies = TRUE)\"",
+        default => "${binary} -e \"install.packages('${name}', repos='${repo}', dependencies = FALSE)\""
+      }
+
+      exec { "install_r_package_${name}":
+        command => $command,
+        unless  => "${binary} -q -e \"'${name}' %in% installed.packages()\" | grep 'TRUE'",
+        require => Class['r']
+      }
+
+    }
+    'windows': {
+
+      if $r_path == '' {
+        $binary = 'r.exe'
+      }
+      else
+      {
+        $binary = $r_path
+      }
+
+      $deps = $dependencies ? {
+        true    => 'TRUE',
+        default => 'FALSE'
+      }
+
+      exec { "install_r_package_${name}":
+        command  => template('r/windows_install_rpackage.ps1.erb'),
+        provider => powershell,
+        unless   => template('r/windows_rpackage_check.ps1.erb'),
+        require  => Class['r']
+      }
+
+    }
+    default: { fail("Not supported on osfamily ${::osfamily}") }
   }
 
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,11 +1,13 @@
-define r::package($r_path = "/usr/bin/R", $repo = "http://cran.rstudio.com", $dependencies = false) {
+define r::package($r_path = '/usr/bin/R', $repo = 'http://cran.rstudio.com', $dependencies = false) {
 
-  exec { "install_r_package_$name":
-    command => $dependencies ? { 
-      true    => "$r_path -e \"install.packages('$name', repos='$repo', dependencies = TRUE)\"",
-      default => "$r_path -e \"install.packages('$name', repos='$repo', dependencies = FALSE)\""
-    },
-    unless  => "$r_path -q -e '\"$name\" %in% installed.packages()' | grep 'TRUE'",
+  $command = $dependencies ? {
+    true    => "${r_path} -e \"install.packages('${name}', repos='${repo}', dependencies = TRUE)\"",
+    default => "${r_path} -e \"install.packages('${name}', repos='${repo}', dependencies = FALSE)\""
+  }
+
+  exec { "install_r_package_${name}":
+    command => $command,
+    unless  => "${r_path} -q -e '\"${name}\" %in% installed.packages()' | grep 'TRUE'",
     require => Class['r']
   }
 

--- a/templates/windows_install_r.ps1.erb
+++ b/templates/windows_install_r.ps1.erb
@@ -1,0 +1,29 @@
+# This Auto-update is how the Choco package installs it.
+# Auto-update idea from https://chocolatey.org/packages/R.Project/3.1.3#comment-1174062797
+$baseUrl='http://cran.at.r-project.org/bin/windows/base/'
+if(!((New-Object System.Net.WebClient).DownloadString($baseUrl) -match "R-(\d\.\d\.\d)-win.exe")) {
+  throw "Unable to determine latest version from $baseUrl"
+}
+
+$version = "$($Matches[1])"
+$downloadUrl = "$baseUrl$($Matches[0])"
+
+Invoke-WebRequest -Uri $downloadUrl -OutFile "${Env:TEMP}\$($Matches[0])"
+
+# Wrapper to block while install completes.
+Invoke-Expression -Command "${Env:TEMP}\$($Matches[0]) /silent; while (`$true) { Start-Sleep -Seconds 5; if (-not (Get-Process -Name $($Matches[0]) -ErrorAction SilentlyContinue)) { break }}"
+
+if(Test-Path "$Env:ProgramFiles\R\R-*\bin\R.exe"){
+    #Put R on System Path
+    $InstallPath = (Get-ChildItem $Env:ProgramFiles\R\R-*\bin | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+    $envPath = $env:PATH
+    if (!$envPath.ToLower().Contains($InstallPath.ToLower())) {
+        Write-Host "PATH environment variable does not have `'$InstallPath`' in it. Adding..."
+        $ActualPath = [Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine)
+        $StatementTerminator = ";"
+        $HasStatementTerminator = $ActualPath -ne $null -and $ActualPath.EndsWith($StatementTerminator)
+        If (!$HasStatementTerminator -and $ActualPath -ne $null) {$InstallPath = $StatementTerminator + $InstallPath}
+
+        [Environment]::SetEnvironmentVariable('Path', $ActualPath + $InstallPath, [System.EnvironmentVariableTarget]::Machine)
+    }
+}

--- a/templates/windows_install_rpackage.ps1.erb
+++ b/templates/windows_install_rpackage.ps1.erb
@@ -1,0 +1,8 @@
+
+# As the System Path has not taken effect during the Puppet run we need to use
+# the absolute path of r.exe. This changes with each version, the path also contains
+# spaces.
+
+$absolute_path = (Get-ChildItem $Env:ProgramFiles\R\R-*\bin\R.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+
+Invoke-Expression -Command "& '$absolute_path' -q -e `"install.packages('<%= scope.lookupvar('name') %>', repos='<%= scope.lookupvar('repo') %>', dependencies = <%= scope.lookupvar('deps') %>)`""

--- a/templates/windows_rpackage_check.ps1.erb
+++ b/templates/windows_rpackage_check.ps1.erb
@@ -1,0 +1,8 @@
+
+# As the System Path has not taken effect during the Puppet run we need to use
+# the absolute path of r.exe. This changes with each version, the path also contains
+# spaces.
+
+$absolute_path = (Get-ChildItem $Env:ProgramFiles\R\R-*\bin\R.exe | Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+
+if(Invoke-Expression -Command "& '$absolute_path' -q -e `"'<%= scope.lookupvar('name') %>' %in% installed.packages()`"" | Select-String 'TRUE'){ exit 0 } else { exit 1 }


### PR DESCRIPTION
Add case and scripts to work on Windows.

Had to install via Powershell as the Chocolatey package does not add the bin to the system path.

Due to links changing we have to use the [same method as the choco package](https://chocolatey.org/packages/R.Project/3.1.3#comment-1174062797) to figure out the current download. As the install path is based on the version we then have to dynamically figure that out.

As the path does not take effect within the Puppet run we need to execute R with the absolute path, again we have to dynamically figure this out.

Tested on Win Server 2012 R2.