### PR TITLE
Adds timeout to exec statement in r::package.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,4 +1,4 @@
-define r::package($r_path = '', $repo = 'http://cran.rstudio.com', $dependencies = false) {
+define r::package($r_path = '', $repo = 'http://cran.rstudio.com', $dependencies = false, $timeout = 300) {
 
     case $::osfamily {
     '^(Debian|RedHat)$': {
@@ -18,6 +18,7 @@ define r::package($r_path = '', $repo = 'http://cran.rstudio.com', $dependencies
 
       exec { "install_r_package_${name}":
         command => $command,
+        timeout => $timeout,
         unless  => "${binary} -q -e \"'${name}' %in% installed.packages()\" | grep 'TRUE'",
         require => Class['r']
       }


### PR DESCRIPTION
This solves an issue when, e.g., installing the r package devtools. While the devtools are installed correctly, the puppet run fails with a supposed timeout. That is because the default timeout for an exec is 300. Allowing to re-define the timeout will prevent this bogus error message.