### PR TITLE
Fix invalid case syntax

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,7 +1,7 @@
 define r::package($r_path = '', $repo = 'http://cran.rstudio.com', $dependencies = false, $timeout = 300) {
 
     case $::osfamily {
-    '^(Debian|RedHat)$': {
+    'Debian', 'RedHat': {
 
       if $r_path == '' {
         $binary = '/usr/bin/R'


### PR DESCRIPTION
This syntax fails in Puppet 3 and 4, so I have corrected it.
https://docs.puppet.com/puppet/3.8/reference/lang_conditional.html#syntax-2
